### PR TITLE
Refactor header to allow search bar headers

### DIFF
--- a/response_operations_social_ui/templates/layouts/base.html
+++ b/response_operations_social_ui/templates/layouts/base.html
@@ -1,15 +1,22 @@
 {% extends 'layouts/base-head.html' %}
 {% block base %}
-  {%- block body %}
+  {% block body %}
     <body style="position: relative; height: auto; min-height: 100%;">
     <div class="page account">
       <div class="page__content">
-        {% include 'partials/header.html' %}
+        <div class="skip">
+          <a class="skip__link" href="#main">Skip to content</a>
+        </div>
+        <header class="page__header">
+          {% include 'partials/header-logo.html' %}
+          {% include 'partials/banner.html' %}
+          {% block header %}{% endblock %}
+        </header>
         <div class="container page__container">
-          {%- block main %}{% endblock main -%}
+          {% block main %}{% endblock main %}
         </div>
       </div>
     </div>
     </body>
-  {% endblock body -%}
+  {% endblock body %}
 {% endblock %}

--- a/response_operations_social_ui/templates/partials/header.html
+++ b/response_operations_social_ui/templates/partials/header.html
@@ -1,7 +1,0 @@
-<div class="skip">
-    <a class="skip__link" href="#main">Skip to content</a>
-</div>
-<header class="page__header">
-    {% include 'partials/header-logo.html' %}
-    {% include 'partials/banner.html' %}
-</header>

--- a/response_operations_social_ui/templates/social-view-case-details.html
+++ b/response_operations_social_ui/templates/social-view-case-details.html
@@ -1,7 +1,11 @@
 {% extends "layouts/base.html" %}
 {% block page_title %}Social | Survey Data Collection{% endblock %}
+
+{% block header %}
+  {% include 'partials/social-case-search.html' %}
+{% endblock %}
+
 {% block main %}
-{% include 'partials/social-case-search.html' %}
   <div class="container page__container">
     {% for msg in get_flashed_messages(category_filter=["success"]) %}
       <div class="panel panel--simple panel--success u-mt-l">

--- a/response_operations_social_ui/templates/social.html
+++ b/response_operations_social_ui/templates/social.html
@@ -1,8 +1,11 @@
 {% extends "layouts/base.html" %}
 {% block page_title %}Social | Survey Data Collection{% endblock %}
 
+{% block header %}
+  {% include 'partials/social-case-search.html' %}
+{% endblock %}
+
 {% block main %}
-{% include 'partials/social-case-search.html' %}
   <div role="main" id="main" class="page__main">
     <div class="grid">
       <div class="grid__col col-12@m">


### PR DESCRIPTION
### Context
As part of the refactoring to split this out into it's own repo we had to change how the headers were included on the social pages. This PR fixes it so that the case search bar appears correctly and only on the pages it should

### What has changed
* Removed header partial
* Add components from header partial to base layout
* Add header block to allow components to be added to the header
* Add the social case search into the headers of the pages it should appear on

### How to test
The social case search bar should correctly appear on the home and case details pages, but not show when the user is not signed in. 