### PR TITLE
Refactor unit tests

### DIFF
--- a/tests/views/__init__.py
+++ b/tests/views/__init__.py
@@ -8,7 +8,3 @@ class ViewTestCase(TestCase):
     def setUp(self):
         self.app = create_app('TestingConfig')
         self.client = self.app.test_client()
-        self.setup_data()
-
-    def setup_data(self):
-        raise NotImplementedError

--- a/tests/views/social/__init__.py
+++ b/tests/views/social/__init__.py
@@ -1,0 +1,36 @@
+import json
+import os
+
+from config import TestingConfig
+from tests.views import ViewTestCase
+
+
+class SocialViewTestCase(ViewTestCase):
+    case_id = "8849c299-5014-4637-bd2b-fc866aeccdf5"
+    sample_unit_id = "519bb700-1bd9-432d-9db7-d34ea1727415"
+    collection_exercise_id = "6553d121-df61-4b3a-8f43-e0726666b8cc"
+    ru_ref = "LMS0001"
+
+    get_case_by_id_url = f'{TestingConfig.CASE_URL}/cases/{case_id}?iac=true'
+    iac_url = f'{TestingConfig.CASE_URL}/cases/{case_id}/iac'
+    get_sample_attributes_by_id_url = f'{TestingConfig.SAMPLE_URL}/samples/{sample_unit_id}/attributes'
+    get_case_events_by_case_id_url = f'{TestingConfig.CASE_URL}/cases/{case_id}/events'
+    get_available_case_group_statuses_direct_url = f'{TestingConfig.CASE_URL}/casegroups/transitions' \
+                                                   f'/{collection_exercise_id}/{ru_ref}'
+    update_case_group_status_url = f'{TestingConfig.CASE_URL}/casegroups/transitions/{collection_exercise_id}/{ru_ref}'
+    get_sample_by_id_url = f'{TestingConfig.SAMPLE_URL}/samples/{sample_unit_id}/attributes'
+
+    test_data_path = os.path.join(os.path.dirname(__file__), '../../test_data/')
+
+    with open(test_data_path + 'case/social_case.json') as fp:
+        mocked_case_details = json.load(fp)
+    with open(test_data_path + 'case/iacs.json') as fp:
+        mocked_iacs = json.load(fp)
+    with open(test_data_path + 'case/iac.json') as fp:
+        mocked_iac = json.load(fp)
+    with open(test_data_path + 'sample/sample_attributes.json') as fp:
+        mocked_sample_attributes = json.load(fp)
+    with open(test_data_path + 'case/social_case_events.json') as fp:
+        mocked_case_events = json.load(fp)
+    with open(test_data_path + 'case/case_group_statuses.json') as fp:
+        mocked_case_group_statuses = json.load(fp)

--- a/tests/views/social/test_generate_iac.py
+++ b/tests/views/social/test_generate_iac.py
@@ -1,51 +1,20 @@
-import json
-
 import requests_mock
 
-from config import TestingConfig
-from tests.views import ViewTestCase
-
-case_id = "8849c299-5014-4637-bd2b-fc866aeccdf5"
-sample_unit_id = "519bb700-1bd9-432d-9db7-d34ea1727415"
-collection_exercise_id = "6553d121-df61-4b3a-8f43-e0726666b8cc"
-ru_ref = "LMS0001"
-
-get_case_by_id_url = f'{TestingConfig.CASE_URL}/cases/{case_id}?iac=true'
-iac_url = f'{TestingConfig.CASE_URL}/cases/{case_id}/iac'
-get_sample_by_id_url = f'{TestingConfig.SAMPLE_URL}/samples/{sample_unit_id}/attributes'
-get_case_events_by_case_id = f'{TestingConfig.CASE_URL}/cases/{case_id}/events'
-url_get_available_case_group_statuses_direct = f'{TestingConfig.CASE_URL}/casegroups/transitions' \
-                                               f'/{collection_exercise_id}/{ru_ref}'
-url_update_case_group_status = f'{TestingConfig.CASE_URL}/casegroups/transitions/{collection_exercise_id}/{ru_ref}'
-
-with open('tests/test_data/case/social_case.json') as fp:
-    mocked_case_details = json.load(fp)
-with open('tests/test_data/case/iacs.json') as fp:
-    mocked_iacs = json.load(fp)
-with open('tests/test_data/case/iac.json') as fp:
-    mocked_iac = json.load(fp)
-with open('tests/test_data/sample/sample_attributes.json') as fp:
-    mocked_sample_attributes = json.load(fp)
-with open('tests/test_data/case/social_case_events.json') as fp:
-    mocked_case_events = json.load(fp)
-with open('tests/test_data/case/case_group_statuses.json') as fp:
-    case_group_statuses = json.load(fp)
+from tests.views.social import SocialViewTestCase
 
 
-class TestGenerateIac(ViewTestCase):
-    def setup_data(self):
-        pass
+class TestGenerateIac(SocialViewTestCase):
 
     @requests_mock.mock()
     def test_generate_iac(self, mock_request):
-        post_data = {"case_id": case_id}
+        post_data = {"case_id": self.case_id}
 
-        mock_request.post(iac_url, json=mocked_iac)
-        mock_request.get(iac_url, json=mocked_iacs)
-        mock_request.get(get_case_by_id_url, json=mocked_case_details)
-        mock_request.get(get_sample_by_id_url, json=mocked_sample_attributes)
-        mock_request.get(get_case_events_by_case_id, json=mocked_case_events)
-        mock_request.get(url_get_available_case_group_statuses_direct, json=case_group_statuses)
+        mock_request.post(self.iac_url, json=self.mocked_iac)
+        mock_request.get(self.iac_url, json=self.mocked_iacs)
+        mock_request.get(self.get_case_by_id_url, json=self.mocked_case_details)
+        mock_request.get(self.get_sample_by_id_url, json=self.mocked_sample_attributes)
+        mock_request.get(self.get_case_events_by_case_id_url, json=self.mocked_case_events)
+        mock_request.get(self.get_available_case_group_statuses_direct_url, json=self.mocked_case_group_statuses)
 
         response = self.client.post(f'/iac', follow_redirects=True, data=post_data)
 

--- a/tests/views/social/test_social_case_search.py
+++ b/tests/views/social/test_social_case_search.py
@@ -28,9 +28,6 @@ def mock_sample_units(postcode):
 
 class TestSocialCaseSearch(ViewTestCase):
 
-    def setup_data(self):
-        pass
-
     @requests_mock.mock()
     def test_valid_postcode(self, mock_request):
         postcode = 'TW9 4ET'

--- a/tests/views/social/test_social_view_case_details.py
+++ b/tests/views/social/test_social_view_case_details.py
@@ -1,53 +1,23 @@
-import json
 from collections import OrderedDict
+import json
 
 import requests_mock
 
-from config import TestingConfig
 from response_operations_social_ui.views.social.social_view_case_details import group_and_order_events
-from tests.views import ViewTestCase
-
-case_id = "8849c299-5014-4637-bd2b-fc866aeccdf5"
-sample_unit_id = "519bb700-1bd9-432d-9db7-d34ea1727415"
-collection_exercise_id = "6553d121-df61-4b3a-8f43-e0726666b8cc"
-ru_ref = "LMS0001"
-
-get_case_by_id_url = f'{TestingConfig.CASE_URL}/cases/{case_id}?iac=true'
-iac_url = f'{TestingConfig.CASE_URL}/cases/{case_id}/iac'
-get_sample_attributes_by_id_url = f'{TestingConfig.SAMPLE_URL}/samples/{sample_unit_id}/attributes'
-get_case_events_by_case_id_url = f'{TestingConfig.CASE_URL}/cases/{case_id}/events'
-get_available_case_group_statuses_direct_url = f'{TestingConfig.CASE_URL}/casegroups/transitions' \
-                                               f'/{collection_exercise_id}/{ru_ref}'
-update_case_group_status_url = f'{TestingConfig.CASE_URL}/casegroups/transitions/{collection_exercise_id}/{ru_ref}'
-
-with open('tests/test_data/case/social_case.json') as fp:
-    mocked_case_details = json.load(fp)
-with open('tests/test_data/case/iacs.json') as fp:
-    mocked_iacs = json.load(fp)
-with open('tests/test_data/case/iac.json') as fp:
-    mocked_iac = json.load(fp)
-with open('tests/test_data/sample/sample_attributes.json') as fp:
-    mocked_sample_attributes = json.load(fp)
-with open('tests/test_data/case/social_case_events.json') as fp:
-    mocked_case_events = json.load(fp)
-with open('tests/test_data/case/case_group_statuses.json') as fp:
-    case_group_statuses = json.load(fp)
+from tests.views.social import SocialViewTestCase
 
 
-class TestSocialViewCaseDetails(ViewTestCase):
-
-    def setup_data(self):
-        pass
+class TestSocialViewCaseDetails(SocialViewTestCase):
 
     @requests_mock.mock()
     def test_get_social_case(self, mock_request):
-        mock_request.get(get_case_by_id_url, json=mocked_case_details)
-        mock_request.get(get_sample_attributes_by_id_url, json=mocked_sample_attributes)
-        mock_request.get(get_case_events_by_case_id_url, json=mocked_case_events)
-        mock_request.get(iac_url, json=mocked_iacs)
-        mock_request.get(get_available_case_group_statuses_direct_url, json=case_group_statuses)
+        mock_request.get(self.get_case_by_id_url, json=self.mocked_case_details)
+        mock_request.get(self.get_sample_attributes_by_id_url, json=self.mocked_sample_attributes)
+        mock_request.get(self.get_case_events_by_case_id_url, json=self.mocked_case_events)
+        mock_request.get(self.iac_url, json=self.mocked_iacs)
+        mock_request.get(self.get_available_case_group_statuses_direct_url, json=self.mocked_case_group_statuses)
 
-        response = self.client.get(f'/case/{case_id}', follow_redirects=True)
+        response = self.client.get(f'/case/{self.case_id}', follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("LMS0001".encode(), response.data)
@@ -56,11 +26,11 @@ class TestSocialViewCaseDetails(ViewTestCase):
 
     @requests_mock.mock()
     def test_get_social_sample_attributes_fail(self, mock_request):
-        mock_request.get(get_case_by_id_url, json=mocked_case_details)
-        mock_request.get(get_sample_attributes_by_id_url, status_code=500)
-        mock_request.get(iac_url, json=mocked_iacs)
+        mock_request.get(self.get_case_by_id_url, json=self.mocked_case_details)
+        mock_request.get(self.get_sample_attributes_by_id_url, status_code=500)
+        mock_request.get(self.iac_url, json=self.mocked_iacs)
 
-        response = self.client.get(f'/case/{case_id}', follow_redirects=True)
+        response = self.client.get(f'/case/{self.case_id}', follow_redirects=True)
 
         request_history = mock_request.request_history
         self.assertEqual(len(request_history), 2)
@@ -68,22 +38,22 @@ class TestSocialViewCaseDetails(ViewTestCase):
 
     @requests_mock.mock()
     def test_update_case_status_view(self, mock_request):
-        mock_request.get(get_case_by_id_url, json=mocked_case_details)
-        mock_request.get(get_sample_attributes_by_id_url, json=mocked_sample_attributes)
-        mock_request.get(get_case_events_by_case_id_url, json=mocked_case_events)
-        mock_request.get(get_available_case_group_statuses_direct_url, json=case_group_statuses)
+        mock_request.get(self.get_case_by_id_url, json=self.mocked_case_details)
+        mock_request.get(self.get_sample_attributes_by_id_url, json=self.mocked_sample_attributes)
+        mock_request.get(self.get_case_events_by_case_id_url, json=self.mocked_case_events)
+        mock_request.get(self.get_available_case_group_statuses_direct_url, json=self.mocked_case_group_statuses)
 
-        response = self.client.get(f'/case/{case_id}/change-response-status', follow_redirects=True)
+        response = self.client.get(f'/case/{self.case_id}/change-response-status', follow_redirects=True)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("In progress".encode(), response.data)
 
     @requests_mock.mock()
     def test_change_response_status(self, mock_request):
-        mock_request.get(get_case_by_id_url, json=mocked_case_details)
-        mock_request.put(update_case_group_status_url)
+        mock_request.get(self.get_case_by_id_url, json=self.mocked_case_details)
+        mock_request.put(self.update_case_group_status_url)
 
-        response = self.client.post(f'/case/{case_id}/change-response-status?status_updated=True&updated_'
+        response = self.client.post(f'/case/{self.case_id}/change-response-status?status_updated=True&updated_'
                                     f'status=PRIVACY_DATA_CONFIDENTIALITY_CONCERNS',
                                     data={'event': 'LEGITIMACY_CONCERNS'})
 
@@ -94,18 +64,18 @@ class TestSocialViewCaseDetails(ViewTestCase):
     @requests_mock.mock()
     def test_outcome_event_detail_is_displayed(self, mock_request):
         # Given
-        with open('tests/test_data/case/social_case_unknown_eligibility_status.json') as fp:
+        with open(self.test_data_path + 'case/social_case_unknown_eligibility_status.json') as fp:
             mocked_case_details_unknown_eligibility = json.load(fp)
-        with open('tests/test_data/case/social_case_events_unknown_eligibility.json') as fp:
+        with open(self.test_data_path + 'case/social_case_events_unknown_eligibility.json') as fp:
             mocked_case_events_unknown_eligibility = json.load(fp)
-        mock_request.get(get_case_by_id_url, json=mocked_case_details_unknown_eligibility)
-        mock_request.get(get_case_events_by_case_id_url, json=mocked_case_events_unknown_eligibility)
-        mock_request.get(get_available_case_group_statuses_direct_url, json=case_group_statuses)
-        mock_request.get(get_sample_attributes_by_id_url, json=mocked_sample_attributes)
-        mock_request.get(iac_url, json=mocked_iacs)
+        mock_request.get(self.get_case_by_id_url, json=mocked_case_details_unknown_eligibility)
+        mock_request.get(self.get_case_events_by_case_id_url, json=mocked_case_events_unknown_eligibility)
+        mock_request.get(self.get_available_case_group_statuses_direct_url, json=self.mocked_case_group_statuses)
+        mock_request.get(self.get_sample_attributes_by_id_url, json=self.mocked_sample_attributes)
+        mock_request.get(self.iac_url, json=self.mocked_iacs)
 
         # When
-        response = self.client.get(f'/case/{case_id}')
+        response = self.client.get(f'/case/{self.case_id}')
 
         # Then
         self.assertIn(b'633 Wrong Address', response.data)

--- a/tests/views/test_sign_in.py
+++ b/tests/views/test_sign_in.py
@@ -1,17 +1,14 @@
-import unittest
-
 import jwt
 import requests_mock
 
 from config import TestingConfig
 from response_operations_social_ui import create_app
-
+from tests.views.social import SocialViewTestCase
 
 url_sign_in_data = f'{TestingConfig.UAA_SERVICE_URL}/oauth/token'
-url_surveys = f'{TestingConfig.SURVEY_URL}/surveys'
 
 
-class TestSignIn(unittest.TestCase):
+class TestSignIn(SocialViewTestCase):
 
     def setUp(self):
         payload = {'user_id': 'test-id',
@@ -112,31 +109,35 @@ class TestSignIn(unittest.TestCase):
         self.assertIn("Find case by postcode".encode(), response.data)
 
     @requests_mock.mock()
-    @unittest.skip("Re-write test for a social page.")
-    # TODO: Re-write this test for a Social Page.
     def test_sign_in_next_url(self, mock_request):
+        # Given
+        mock_request.get(self.get_case_by_id_url, json=self.mocked_case_details)
+        mock_request.get(self.get_sample_attributes_by_id_url, json=self.mocked_sample_attributes)
+        mock_request.get(self.get_case_events_by_case_id_url, json=self.mocked_case_events)
+        mock_request.get(self.iac_url, json=self.mocked_iacs)
+        mock_request.get(self.get_available_case_group_statuses_direct_url, json=self.mocked_case_group_statuses)
         with self.client.session_transaction() as session:
-            session['next'] = '/surveys'
+            session['next'] = f'/case/{self.case_id}'
         mock_request.post(url_sign_in_data, json={"access_token": self.access_token.decode()}, status_code=201)
-        mock_request.get(url_surveys, json=[{
-            "id": "75b19ea0-69a4-4c58-8d7f-4458c8f43f5c",
-            "legalBasis": "Statistics of Trade Act 1947",
-            "longName": "Monthly Business Survey - Retail Sales Index",
-            "shortName": "RSI",
-            "surveyRef": "023"}],
-            status_code=200)
 
+        # When
         response = self.client.post("/sign-in", follow_redirects=True,
                                     data={"username": "user", "password": "pass"})
 
+        # Then
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Surveys".encode(), response.data)
-        self.assertIn("Legal basis".encode(), response.data)
-        self.assertIn("Statistics of Trade Act 1947".encode(), response.data)
+        self.assertIn(b'Find case by postcode', response.data)
+        self.assertIn(self.mocked_sample_attributes['attributes']['ADDRESS_LINE1'].encode(), response.data)
+        self.assertIn(self.mocked_sample_attributes['attributes']['ADDRESS_LINE2'].encode(), response.data)
+        self.assertIn(self.mocked_sample_attributes['attributes']['LOCALITY'].encode(), response.data)
+        self.assertIn(self.mocked_sample_attributes['attributes']['TOWN_NAME'].encode(), response.data)
+        self.assertIn(self.mocked_sample_attributes['attributes']['POSTCODE'].encode(), response.data)
+        self.assertIn(self.mocked_sample_attributes['attributes']['TLA'].encode(), response.data)
+        self.assertIn(self.mocked_sample_attributes['attributes']['REFERENCE'].encode(), response.data)
 
     def test_sign_out_deleting_session_variables(self):
         with self.client.session_transaction() as session:
-            session['next'] = '/messages/bricks'
+            session['next'] = f'/case/{self.case_id}'
         response = self.client.get('/logout', follow_redirects=True)
         self.assertIn(b'You are now signed out', response.data)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
### Context
The unit tests were copied and stripped down from r-ops but some business references remained and one of the tests needed re-writing. This PR refactors the tests and removes remaining business references

### What has changed
* Created a social view test case class for common code between social view tests
* Re-wrote test that still contained references to business pages
* Use relative file paths for test data

### How to test
No unit tests should now be skipped and the coverage should remain. Also you should now be able to run the social view tests from any directory without getting file path issues