### PR TITLE
Fix uaa audience

### DIFF
--- a/config.py
+++ b/config.py
@@ -127,7 +127,7 @@ class DevelopmentConfig(Config):
     SURVEY_AUTH = (SURVEY_USERNAME, SURVEY_PASSWORD)
 
     UAA_SERVICE_URL = os.getenv('UAA_SERVICE_URL', 'http://localhost:9080')
-    UAA_CLIENT_ID = os.getenv('UAA_CLIENT_ID', 'response_operations')
+    UAA_CLIENT_ID = os.getenv('UAA_CLIENT_ID', 'response_operations_social')
     UAA_CLIENT_SECRET = os.getenv('UAA_CLIENT_SECRET', 'password')
 
     FEATURE_ENABLE_CLOSE_CONVERSATION = strtobool(os.getenv('FEATURE_ENABLE_CLOSE_CONVERSATION', 'True'))

--- a/response_operations_social_ui/common/token_decoder.py
+++ b/response_operations_social_ui/common/token_decoder.py
@@ -14,7 +14,7 @@ def decode_access_token(access_token):
     decoded_jwt = jwt.decode(
         access_token,
         key=uaa_public_key,
-        audience='response_operations',
+        audience='response_operations_social',
         leeway=10
     )
     return decoded_jwt

--- a/tests/views/test_sign_in.py
+++ b/tests/views/test_sign_in.py
@@ -15,7 +15,7 @@ class TestSignIn(unittest.TestCase):
 
     def setUp(self):
         payload = {'user_id': 'test-id',
-                   'aud': 'response_operations'}
+                   'aud': 'response_operations_social'}
 
         app = create_app('TestingConfig')
         key = app.config['UAA_PUBLIC_KEY']


### PR DESCRIPTION
### Context
The uaa audience used for authentication was still set incorrectly, needs updating so that the app can authenticate through UI registered as it's own client.

### What has changed
* The uaa token audience has been updated

### How to test
Run this branch with the branch of docker dev
https://github.com/ONSdigital/ras-rm-docker-dev/pull/88