### PR TITLE
Fix direct use of transient module

### DIFF
--- a/response_operations_social_ui/views/social/social_view_case_details.py
+++ b/response_operations_social_ui/views/social/social_view_case_details.py
@@ -3,7 +3,6 @@ import logging
 
 from flask import render_template, request, redirect, url_for, flash, get_flashed_messages
 from flask_login import login_required
-from more_itertools import first_true
 from structlog import wrap_logger
 
 from response_operations_social_ui.common.social_outcomes import map_social_case_status, map_social_status_groups, \
@@ -19,9 +18,9 @@ logger = wrap_logger(logging.getLogger(__name__))
 def view_social_case_details(case_id):
     context = build_view_social_case_context(case_id)
     logger.debug("view_social_case_details", case_id=case_id, status=context.get('status'))
-    new_iac_tuple = first_true(get_flashed_messages(with_categories=True),
-                               None,
-                               lambda category_and_message: category_and_message[0] == 'new_iac')
+    new_iac_tuple = next(category_and_message for category_and_message
+                         in get_flashed_messages(with_categories=True)
+                         if category_and_message[0] == 'new_iac')
     if new_iac_tuple:
         context['new_iac'] = f'{new_iac_tuple[1][:4]} {new_iac_tuple[1][4:8]} {new_iac_tuple[1][8:]}'
 

--- a/tests/views/social/__init__.py
+++ b/tests/views/social/__init__.py
@@ -12,6 +12,7 @@ class SocialViewTestCase(ViewTestCase):
     ru_ref = "LMS0001"
 
     get_case_by_id_url = f'{TestingConfig.CASE_URL}/cases/{case_id}?iac=true'
+    post_case_new_iac_url = f'{TestingConfig.CASE_URL}/cases/{case_id}/iac'
     iac_url = f'{TestingConfig.CASE_URL}/cases/{case_id}/iac'
     get_sample_attributes_by_id_url = f'{TestingConfig.SAMPLE_URL}/samples/{sample_unit_id}/attributes'
     get_case_events_by_case_id_url = f'{TestingConfig.CASE_URL}/cases/{case_id}/events'

--- a/tests/views/social/test_social_view_case_details.py
+++ b/tests/views/social/test_social_view_case_details.py
@@ -104,3 +104,19 @@ class TestSocialViewCaseDetails(SocialViewTestCase):
 
         # Then
         self.assertEqual(expected_grouped_ordered_events, actual_grouped_ordered_events)
+
+    @requests_mock.mock()
+    def test_new_iac_is_displayed(self, mock_request):
+        mock_request.get(self.get_case_by_id_url, json=self.mocked_case_details)
+        mock_request.get(self.get_sample_attributes_by_id_url, json=self.mocked_sample_attributes)
+        mock_request.get(self.get_case_events_by_case_id_url, json=self.mocked_case_events)
+        mock_request.get(self.iac_url, json=self.mocked_iacs)
+        mock_request.get(self.get_available_case_group_statuses_direct_url, json=self.mocked_case_group_statuses)
+        mock_request.post(self.post_case_new_iac_url, json={'iac': 'testiac12345'})
+
+        response = self.client.post('/iac',
+                                    data=f'case_id={self.case_id}',
+                                    follow_redirects=True,
+                                    content_type='application/x-www-form-urlencoded')
+
+        self.assertIn(b'test iac1 2345', response.data)


### PR DESCRIPTION
The previous PR (https://github.com/ONSdigital/response-operations-social-ui/pull/15) imported and used a module which is only present as a transient dependency which caused issues running in cloudfoundry (and should not be done anyway). This PR removes that use and introduces a missing test for functionality.