### PR TITLE
Update prod manifest name and instances

### DIFF
--- a/manifests/manifest-prod.yml
+++ b/manifests/manifest-prod.yml
@@ -1,10 +1,9 @@
 applications:
 - name: response-operations-social-ui
   disk_quota: 1G
-  instances: 1
+  instances: 2
   memory: 512M
   stack: cflinuxfs2
   timeout: 180
   services:
   - res-ops-redis
-


### PR DESCRIPTION
Rename the manifest used for production/preprod to manifest-prod.yml and up the instance count to 2.

Requires a pipeline change to be flown before merge.