### PR TITLE
correct the docker make target to use the correct repository name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ start:
 	pipenv run python run.py
 
 docker: test
-	docker build -t sdcplatform/response-operations-ui:latest .
+	docker build -t sdcplatform/response-operations-social-ui:latest .


### PR DESCRIPTION
The Docker make target currently use sdcplatform/response-operations-ui but it should be using sdcplatform/response-operations-social-ui