### PR TITLE
SUS059 Inform SEL users that SEL will be unavailable during Planned Maintenance

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,6 +17,7 @@ class Config(object):
     REDIS_HOST = os.getenv('REDIS_HOST')
     REDIS_PORT = os.getenv('REDIS_PORT')
     REDIS_DB = os.getenv('REDIS_DB', 0)
+    REDIS_MAINTENANCE_KEY = os.getenv('REDIS_MAINTENANCE_KEY', 'response-operations-social-ui:maintenance')
     SECURE_COOKIES = strtobool(os.getenv('SECURE_COOKIES', 'True'))
     USE_SESSION_FOR_NEXT = True
 
@@ -59,6 +60,7 @@ class DevelopmentConfig(Config):
     REDIS_HOST = os.getenv('REDIS_HOST', "localhost")
     REDIS_PORT = os.getenv('REDIS_PORT', 7379)
     REDIS_DB = os.getenv('REDIS_DB', 0)
+    REDIS_MAINTENANCE_KEY = os.getenv('REDIS_MAINTENANCE_KEY', 'response-operations-social-ui:maintenance')
     SECURE_COOKIES = strtobool(os.getenv('SECURE_COOKIES', 'False'))
 
     # Service Config
@@ -98,4 +100,4 @@ class TestingConfig(DevelopmentConfig):
     SESSION_PERMANENT = False
     UAA_PUBLIC_KEY = 'Test'
     SECRET_KEY = 'sekrit!'
-
+    REDIS_SERVICE = 'test-redis'

--- a/response_operations_social_ui/cloud/cloudfoundry.py
+++ b/response_operations_social_ui/cloud/cloudfoundry.py
@@ -1,15 +1,17 @@
 import cfenv
-from flask import current_app
 
 
 class ONSCloudFoundry(object):
-    def __init__(self):
-        self._cf_env = cfenv.AppEnv()
+    def __init__(self, redis_name):
+        self.cf_env = cfenv.AppEnv()
+        self.redis_name = redis_name
+        self._redis = None
 
     @property
     def detected(self):
-        return self._cf_env.app
+        return self.cf_env.app
 
     @property
     def redis(self):
-        return self._cf_env.get_service(name=current_app.config['REDIS_SERVICE'])
+        self._redis = self._redis or self.cf_env.get_service(name=self.redis_name)
+        return self._redis

--- a/response_operations_social_ui/maintenance.py
+++ b/response_operations_social_ui/maintenance.py
@@ -1,0 +1,25 @@
+import json
+import logging
+
+import redis
+from flask import current_app, g
+from structlog import wrap_logger
+
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+def check_for_messages():  # pylint: disable=unused-variable
+    try:
+        redis_connection = current_app.config['REDIS_CONNECTION']
+        maintenance_message = redis_connection.get(current_app.config['REDIS_MAINTENANCE_KEY'])
+        if maintenance_message:
+            maintenance_message = json.loads(maintenance_message)
+            logger.info('Maintenance message received from redis')
+            g.maintenance_message = maintenance_message
+    except KeyError:
+        logger.debug('Redis connection does not exist')
+    except redis.exceptions.RedisError as e:
+        logger.error('Failed to connect to redis', message=str(e))
+    except TypeError as e:
+        logger.error('Unexpected message type received from redis', message=str(e))

--- a/response_operations_social_ui/templates/layouts/base.html
+++ b/response_operations_social_ui/templates/layouts/base.html
@@ -16,7 +16,10 @@
         </header>
 
         <div class="container container--wide page__container">
-          {% block main %}{% endblock main %}
+        {% if g.maintenance_message %}
+          {% include 'partials/planned-maintenance-message.html' %}
+        {% endif %}
+        {% block main %}{% endblock main %}
         </div>
 
       </div>

--- a/response_operations_social_ui/templates/partials/planned-maintenance-message.html
+++ b/response_operations_social_ui/templates/partials/planned-maintenance-message.html
@@ -1,0 +1,13 @@
+<div class="grid">
+  <div class="grid__col col-12@m">
+    <div role="main" class="page__main col-6@m">
+      <div class="panel panel--simple panel--info u-mb-s">
+        <div class="panel__body">
+          {% for para in g.maintenance_message.text.split('\n') %}
+            <p class="mars">{{ para|safe }}</p>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/scripts/planned_maintenance.py
+++ b/scripts/planned_maintenance.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+import argparse
+import json
+import os
+import sys
+
+import redis
+
+sys.path.append(os.path.join(os.path.dirname(__file__), os.path.pardir))
+
+import config  # NOQA
+from response_operations_social_ui.cloud.cloudfoundry import ONSCloudFoundry  # NOQA
+
+
+MAINTENANCE_MSG = {"text": "This site will be temporarily unavailable for maintenance <strong>{message}</strong>.\nWe apologise for any inconvenience this may cause."}  # NOQA
+
+try:
+    config_info = getattr(config, os.environ['APP_SETTINGS'])
+except (AttributeError, KeyError):
+    config_info = config.DevelopmentConfig
+
+cf = ONSCloudFoundry(redis_name=config_info.REDIS_SERVICE)
+if cf.detected and cf.redis:
+    print("Cloud Foundry detected, setting service configurations")
+    config_info.REDIS_HOST = cf.redis.credentials['host']
+    config_info.REDIS_PORT = cf.redis.credentials['port']
+
+redis_connection = redis.Redis(host=config_info.REDIS_HOST, port=config_info.REDIS_PORT)
+
+
+def main(message, ttl=None):
+    message_dict = MAINTENANCE_MSG.copy()
+    message_dict['text'] = message_dict['text'].format(message=message)
+    redis_connection.set(config_info.REDIS_MAINTENANCE_KEY, json.dumps(message_dict))
+    if ttl is not None:
+        redis_connection.expire(config_info.REDIS_MAINTENANCE_KEY, ttl)
+        print(f'Message set: """{message_dict["text"]}""" TTL: {ttl}s')
+    else:
+        print(f'Message set: """{message_dict["text"]}"""')
+    print(f'Remove with: pipenv run python {__file__} --remove')
+
+
+def remove_message():
+    redis_connection.delete(config_info.REDIS_MAINTENANCE_KEY)
+    print('Removed')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Set a planned maintenance message for Response Operations Social UI')
+    parser.add_argument('message', nargs='?', type=str,
+                        help=f"""message to be displayed as part of the planned maintenance"""
+                             f"""\ne.g.: \"{MAINTENANCE_MSG['text']}\""""
+                        )
+    parser.add_argument('--remove', action='store_true', help='remove the planned maintenance message')
+    parser.add_argument('--ttl', type=int, help='add a time to live in seconds')
+    args = parser.parse_args()
+    if args.remove:
+        remove_message()
+    elif args.message:
+        main(args.message, ttl=args.ttl)
+    else:
+        parser.print_help()

--- a/tests/test_create_app.py
+++ b/tests/test_create_app.py
@@ -1,7 +1,9 @@
 import json
 import os
 import unittest
+from unittest.mock import patch
 
+import redis
 from flask import app
 
 from response_operations_social_ui import create_app
@@ -15,7 +17,7 @@ class TestCreateApp(unittest.TestCase):
                 'credentials': {
                     'host': 'test_host',
                     'name': 'redis-hostname',
-                    'port': 'test_port'
+                    'port': '1'
                 },
                 'label': 'broker-name',
                 'name': 'test-redis',
@@ -39,7 +41,6 @@ class TestCreateApp(unittest.TestCase):
         app.testing = True
         os.environ['APP_SETTINGS'] = 'TestingConfig'
 
-    # Check that we can initialise app and access it's config
     def test_create_app(self):
         test_app = create_app('TestingConfig')
         self.assertEqual(test_app.config['REDIS_HOST'], 'localhost')
@@ -50,4 +51,15 @@ class TestCreateApp(unittest.TestCase):
 
         test_app = create_app()
         self.assertEqual(test_app.config['REDIS_HOST'], 'test_host')
-        self.assertEqual(test_app.config['REDIS_PORT'], 'test_port')
+        self.assertEqual(test_app.config['REDIS_PORT'], '1')
+
+    @patch('redis.client.StrictRedis.ping')
+    def test_create_app_without_redis(self, patched_ping):
+        patched_ping.side_effect = redis.exceptions.ConnectionError
+        test_app = create_app()
+        self.assertNotIn('REDIS_CONNECTION', test_app.config)
+
+    @patch('redis.client.StrictRedis.ping')
+    def test_create_app_with_redis(self, _):
+        test_app = create_app()
+        self.assertIn('REDIS_CONNECTION', test_app.config)


### PR DESCRIPTION
# Motivation and Context
As a: A SEL user
I need: to be informed that I will be prevented from using the system when it is made unavailable for planned maintenance
So that: I am aware in advance of planned unavailability

[SUS059](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/961282086/SUS059+Inform+SEL+users+that+SEL+will+be+unavailable+during+Planned+Maintenance)

# What has changed
- added a new maintenance "middleware" (flask `before_request`) which polls redis for messages
- added a script for posting maintenance messages to redis

# How to test?
1. start services
2. `pipenv run python scripts/planned_maintenance "[my message]"`
e.g.: `pipenv run python scripts/planned_maintenance "very soon"`
3. Open http://0.0.0.0:8086/
4. Check maintenance message is present in an info panel.
5. `pipenv run python scripts/planned_maintenance --remove`
6. Refresh the page.
7. Make sure the maintenance message is no longer present.

NB:
- TTL expiry can be added with the `-ttl [N sconds]` flag.

# Screenshots

![image](https://user-images.githubusercontent.com/28348457/49291638-eb0a4c00-f4a2-11e8-98c5-39e1ac2f8860.png)

